### PR TITLE
zuul: Replace ensure-virtualenv with ensure-pip

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -248,17 +248,6 @@
     label:
       jobs:
         - node-image-build-1
-        - node-image-build-2
-        - node-image-build-3
-        - node-image-build-4
-        - node-image-build-cloud-in-a-box-1
-        - node-image-build-cloud-in-a-box-2
-        - node-image-build-cloud-in-a-box-edge-2
-        - node-image-build-cloud-in-a-box-kubernetes-2
-        - node-image-build-osism-1
-        - node-image-build-osism-2
-        - node-image-build-osism-3
-        - node-image-build-osism-4
     post:
       jobs:
         - node-image-publish-1:

--- a/playbooks/pre.yml
+++ b/playbooks/pre.yml
@@ -4,7 +4,7 @@
   hosts: all
 
   roles:
-    - ensure-virtualenv
+    - ensure-pip
     - ensure-docker
 
   tasks:


### PR DESCRIPTION
The latter role includes an apt update, which is needed on a fresh test node. Also the build process later only calls "python3 -m venv" and not "virtualenv", so installing the latter isn't needed.