### PR TITLE
zuul: always build node-image-build-1

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -301,6 +301,7 @@
         - hadolint
         - python-black
         - yamllint
+        - node-image-build-1
     label:
       jobs:
         - node-image-build-1


### PR DESCRIPTION
Always build node-image-build-1 with the zuul label. This way we ensure that everything is working like expected.