### PR TITLE
disable layer3_underlay_builds

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -124,7 +124,6 @@
     vars:
       variant: osism-1
       description: 'Two mirrored NVMe disks with a single logical rootfs volume (/dev/nvme3n1 and /dev/nvme4n1)'
-      layer3_underlay: true
 
 - job:
     name: node-image-build-osism-2
@@ -132,7 +131,6 @@
     vars:
       variant: osism-2
       description: 'Two mirrored NVMe disks with a single logical rootfs volume (/dev/nvme4n1 and /dev/nvme5n1)'
-      layer3_underlay: true
 
 - job:
     name: node-image-build-osism-3
@@ -140,7 +138,6 @@
     vars:
       variant: osism-3
       description: 'Two mirrored NVMe disks with a single logical rootfs volume (/dev/nvme2n1 and /dev/nvme3n1)'
-      layer3_underlay: true
 
 - job:
     name: node-image-build-osism-4
@@ -148,7 +145,6 @@
     vars:
       variant: osism-4
       description: 'Two mirrored NVMe disks with a single logical rootfs volume (/dev/nvme0n1 and /dev/nvme1n1)'
-      layer3_underlay: true
 
 - job:
     name: node-image-publish-1

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 ## Usage of the node images
 
-### Installimg Generic Images
+### Installing generic images
 
-1. Connect one ore more ethernet ports and provide DHCP with gateway- and dns access
+1. Connect one ore more ethernet ports and provide DHCP with gateway- and DNS access
 2. Add the installation media to your system
    * Copy image to USB stick
    * Place the image on your network provisioning environment
@@ -22,13 +22,13 @@
    * user: `osism` (alternatively use `dragon` after the 2nd deployment run)
    * password: `password`
 
-### Installing Layer3 Underlay Images with "BGP on the Host"
+### Installing images with "Routing on the Host"
 
 Normally, for reasons of efficiency, you would like to use the default images provided by OSISM for the installation.
-However, if you want to install systems that use a layer 3 underlay or that use BGP routing
-on layer 3 instead of LACP on layer 2, you have to integrate a number of parameters into the image for the installation.
+However, if you want to install systems that use Routing on the Host you have to integrate a number of parameters
+into the image for the installation.
 
-These parameters are listed in the file “parameters-layer3-underlay-example.yaml” as examples.
+These parameters are listed in the file `parameters-routing-on-the-host.yml.sample` as example.
 
 The installation is then carried out as follows:
 
@@ -38,7 +38,7 @@ The installation is then carried out as follows:
      (the last number of the IPv4 adress is used for building the node ASN, the node IPs, ..)
    * Configure the involved switches to have a BGP peering with the host
 2. Build a node image specific for your environment
-   (see [parameters-layer3-underlay-bgp-to-the-host-example.yml](./parameters-layer3-underlay-bgp-to-the-host-example.yml)
+   (see [parameters-routing-on-the-host.yml.sample](./parameters-routing-on-the-host.yml.sample)
 3. Add the installation media to your system
    * Copy image to USB stick
    * Place the image on your network provisioning environment

--- a/README.md
+++ b/README.md
@@ -5,16 +5,53 @@
 
 ## Usage of the node images
 
-* Copy image to USB stick or place the image on your network provisioning environment (Redfish, BMC mount, ....)
-* Mount the image in the BMC in another way
-* Boot from the device
-* Installation is performed, system shuts down afterwards
-* Unmount the device or remove it and start system again
-* After the first boot the system shuts down once more
-* System is ready for use, by default DHCP is tried on all available interfaces
-* Perform a SSH-login
-  * user: `osism` (alternatively use `dragon` after the 2nd deployment run)
-  * password: `password`
+### Installimg Generic Images
+
+1. Connect one ore more ethernet ports and provide DHCP with gateway- and dns access
+2. Add the installation media to your system
+   * Copy image to USB stick
+   * Place the image on your network provisioning environment
+    (Redfish-BMC Mount)
+3. Boot from the device
+4. Mount the image in the BMC in another way
+5. Installation is performed, system shuts down afterwards
+6. Unmount the device or remove it and start system again
+7. After the first boot the system shuts down once more
+8. Start the system, system is ready for use, by default DHCP is tried on all available interfaces
+9. Perform a SSH-login
+   * user: `osism` (alternatively use `dragon` after the 2nd deployment run)
+   * password: `password`
+
+### Installing Layer3 Underlay Images with "BGP on the Host"
+
+Normally, for reasons of efficiency, you would like to use the default images provided by OSISM for the installation.
+However, if you want to install systems that use a layer 3 underlay or that use BGP routing
+on layer 3 instead of LACP on layer 2, you have to integrate a number of parameters into the image for the installation.
+
+These parameters are listed in the file “parameters-layer3-underlay-example.yaml” as examples.
+
+The installation is then carried out as follows:
+
+1. Configure the BMC of the server hardware and configure the following properties
+   * The hostname of the system
+   * The BMC IP address
+     (the last number of the IPv4 adress is used for building the node ASN, the node IPs, ..)
+   * Configure the involved switches to have a BGP peering with the host
+2. Build a node image specific for your environment
+   (see [parameters-layer3-underlay-bgp-to-the-host-example.yml](./parameters-layer3-underlay-bgp-to-the-host-example.yml)
+3. Add the installation media to your system
+   * Copy image to USB stick
+   * Place the image on your network provisioning environment
+    (Redfish-BMC Mount)
+4. Boot from the device
+   Installation is performed, system shuts down afterwards
+5. Unmount the device or remove it and start system again
+6. After the first boot the system shuts down once more
+7. Start the system, system is ready for use
+   (System starts with a ready to use network setup: dummy interface, frr-config, ...)
+8. Perform a SSH-login
+   * user: `osism` (alternatively use `dragon` after the 2nd deployment run)
+   * password: `password`
 
 ## Creation of specific images
 

--- a/parameters-layer3-underlay-bgp-to-the-host-example.yml
+++ b/parameters-layer3-underlay-bgp-to-the-host-example.yml
@@ -1,0 +1,15 @@
+---
+# The last number of the BMC ip is added (2 digits)
+asn_node_base: '42100210'
+description: Two mirrored NVME disks with a enhanced set of predefined logical volumes
+  (/dev/nvme3n1 and /dev/nvme4n1)
+interface1_asn: '65405'
+interface1_name: enp2s0f0np0
+interface2_asn: '65404'
+interface2_name: enp2s0f1np1
+# The last number of the BMC ip is added (2 digits)
+ipv4_base: 10.10.21.
+# The last number of the BMC ip is added (2 digits)
+ipv6_base: 'fd0c:cc24:75a0:1:10:10:21:'
+layer3_underlay: 'true'
+variant: osism-1

--- a/parameters-routing-on-the-host.yml.sample
+++ b/parameters-routing-on-the-host.yml.sample
@@ -1,7 +1,7 @@
 ---
 # The last number of the BMC ip is added (2 digits)
 asn_node_base: '42100210'
-description: Two mirrored NVME disks with a enhanced set of predefined logical volumes
+description: Two mirrored NVMe disks with a enhanced set of predefined logical volumes
   (/dev/nvme3n1 and /dev/nvme4n1)
 interface1_asn: '65405'
 interface1_name: enp2s0f0np0


### PR DESCRIPTION
- disable the build of layer3 underlays because this is a envrionment/usert specific thing
- added some documentation which describes how to use layer3 / bgp-to-the-host node images
- improved the documentation of the general installtion procedure