### PR TITLE
Add option to convert IPv6 addresses to hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Node Images
 
 | :zap: When booting from one of these images, all data on the disks will be destroyed without confirmation. :zap: |
-| ---------------------------------------------------------------------------------------------------------------- |
+|------------------------------------------------------------------------------------------------------------------|
 
 ## Usage of the node images
 
@@ -13,9 +13,9 @@ The disks used must be at least 480 GByte in size.
 
 1. Connect one ore more ethernet ports and provide DHCP with gateway- and DNS access
 2. Add the installation media to your system
-   - Copy image to USB stick
-   - Place the image on your network provisioning environment
-     (Redfish-BMC Mount)
+   * Copy image to USB stick
+   * Place the image on your network provisioning environment
+    (Redfish-BMC Mount)
 3. Boot from the device
 4. Mount the image in the BMC in another way
 5. Installation is performed, system shuts down afterwards
@@ -23,8 +23,8 @@ The disks used must be at least 480 GByte in size.
 7. After the first boot the system shuts down once more
 8. Start the system, system is ready for use, by default DHCP is tried on all available interfaces
 9. Perform a SSH-login
-   - user: `osism` (alternatively use `dragon` after the 2nd deployment run)
-   - password: `password`
+   * user: `osism` (alternatively use `dragon` after the 2nd deployment run)
+   * password: `password`
 
 ### Installing images with "Routing on the Host"
 
@@ -37,16 +37,16 @@ These parameters are listed in the file `parameters-routing-on-the-host.yml.samp
 The installation is then carried out as follows:
 
 1. Configure the BMC of the server hardware and configure the following properties
-   - The hostname of the system
-   - The BMC IP address
+   * The hostname of the system
+   * The BMC IP address
      (the last number of the IPv4 adress is used for building the node ASN, the node IPs, ..)
-   - Configure the involved switches to have a BGP peering with the host
+   * Configure the involved switches to have a BGP peering with the host
 2. Build a node image specific for your environment
    (see [parameters-routing-on-the-host.yml.sample](./parameters-routing-on-the-host.yml.sample)
 3. Add the installation media to your system
-   - Copy image to USB stick
-   - Place the image on your network provisioning environment
-     (Redfish-BMC Mount)
+   * Copy image to USB stick
+   * Place the image on your network provisioning environment
+    (Redfish-BMC Mount)
 4. Boot from the device
    Installation is performed, system shuts down afterwards
 5. Unmount the device or remove it and start system again
@@ -54,8 +54,8 @@ The installation is then carried out as follows:
 7. Start the system, system is ready for use
    (System starts with a ready to use network setup: dummy interface, frr-config, ...)
 8. Perform a SSH-login
-   - user: `osism` (alternatively use `dragon` after the 2nd deployment run)
-   - password: `password`
+   * user: `osism` (alternatively use `dragon` after the 2nd deployment run)
+   * password: `password`
 
 ## Creation of specific images
 
@@ -127,13 +127,12 @@ ssh_public_key_user_osism: '# no key specified'
 ```
 
 Build the image:
-
-```bash
+````bash
 $ ./create-image.sh \
     --build node-image-build-osism-1 \
     --config Supermicro_A2SDV-8C-LN8F.yml \
     --parameters "ipv6_base=fd0c:cc24:75a0:1:10:10:21:" "layer3-underlay=true"
-```
+````
 
 ### Charateristics of layer3_underlay deployments
 
@@ -142,13 +141,13 @@ The parameter `layer3_underlay: 'true'` enables the support for layer3 underlays
 The logic currently implemented is relatively simple and behaves as follows:
 
 - The following must be configured on the system's BMC:
-  - the hostname of the system
-  - The BMC IPv4
+   - the hostname of the system
+   - The BMC IPv4
 - The last group of numbers is taken from the BMC IPv4 configured in the system
   and used as the basis for other configurations (`node-suffix`):
-  - the IPV4 of the “dummy0” interface: `<ipv4_base><node-suffix>>`
-  - the IPV6 of the “dummy0” interface : `<ipv6_base><node-suffix>`
-  - the node ASN of the FRR instance of the node: `<asn_node_base><node-suffix>`
+   - the IPV4 of the “dummy0” interface: `<ipv4_base><node-suffix>>`
+   - the IPV6 of the “dummy0” interface : `<ipv6_base><node-suffix>`
+   - the node ASN of the FRR instance of the node: `<asn_node_base><node-suffix>`
 - The image installs itself with deactivated IPv6 Router Advertisements because otherwise Ubuntu Autoinstall
   tries to reach package sources (so no internet connection is necessary)
 - The names of two Ethernet interfaces and the corresponding ASNs of the switches must be specified (e.g. `interface1_asn` and `interface1_name`)
@@ -159,27 +158,27 @@ The logic currently implemented is relatively simple and behaves as follows:
 
 #### Variant 1
 
-[Standard Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-1.iso) -
-[[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-1.iso.CHECKSUM)
+[Standard Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-1.iso) - 
+  [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-1.iso.CHECKSUM)
 
 ![Disk layout](assets/disklayout-1.drawio.png "Disk layout")
 
 #### Variant 2
 
-- [Standard Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-2.iso) -
+* [Standard Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-2.iso) - 
   [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-2.iso.CHECKSUM)
-- Regio Cloud Images<BR>
+* Regio Cloud Images<BR>
   used for the REGIO.cloud environment, variants of the used devices.
-  - [OSISM 1](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-1.iso) -
+  * [OSISM 1](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-1.iso) -
     [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-1.iso.CHECKSUM)<BR>
     Like `Variant 2`, with `/dev/nvme3n1` and `/dev/nvme4n1`<BR>
-  - [OSISM 2](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-2.iso) -
+  * [OSISM 2](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-2.iso) - 
     [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-2.iso.CHECKSUM)<BR>
     Like `Variant 2`, with `/dev/nvme4n1` and `/dev/nvme5n1`<BR>
-  - [OSISM 3](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-3.iso) -
+  * [OSISM 3](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-3.iso) - 
     [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-3.iso.CHECKSUM)<BR>
     Like `Variant 2`, with `/dev/nvme2n1` and `/dev/nvme3n1`<BR>
-  - [OSISM 4](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-4.iso) -
+  * [OSISM 4](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-4.iso) - 
     [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-4.iso.CHECKSUM)<BR>
     Like `Variant 2`, with `/dev/nvme0n1` and `/dev/nvme1n1`<BR>
 
@@ -187,15 +186,15 @@ The logic currently implemented is relatively simple and behaves as follows:
 
 #### Variant 3
 
-[Standard Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-3.iso) -
-[[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-3.iso.CHECKSUM)
+[Standard Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-3.iso) - 
+  [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-3.iso.CHECKSUM)
 
 ![Disk layout](assets/disklayout-3.drawio.png "Disk layout")
 
 #### Variant 4
 
-[Standard Images](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-4.iso) -
-[[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-4.iso.CHECKSUM)
+[Standard Images](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-4.iso) - 
+  [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-4.iso.CHECKSUM)
 
 ![Disk layout](assets/disklayout-4.drawio.png "Disk layout")
 
@@ -205,12 +204,12 @@ The [cloud in a box](https://osism.tech/docs/guides/other-guides/cloud-in-a-box)
 
 ### Variant 1 - SCSI images
 
-- [Sandbox Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-1.iso) -
+* [Sandbox Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-1.iso) - 
   [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-1.iso.CHECKSUM)
-- [Kubernetes Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-kubernetes-1.iso) -
+* [Kubernetes Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-kubernetes-1.iso) - 
   [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-kubernetes-1.iso.CHECKSUM)<BR>
   Like Sandbox `Variant 1`, with `CLOUD_IN_A_BOX_TYPE=kubernetes` boot parameter.
-- [Ironic Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-ironic-1.iso) -
+* [Ironic Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-ironic-1.iso) - 
   [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-ironic-1.iso.CHECKSUM)<BR>
   Like Sandbox `Variant 1`, with `CLOUD_IN_A_BOX_TYPE=ironic` boot parameter.
 
@@ -218,17 +217,17 @@ The [cloud in a box](https://osism.tech/docs/guides/other-guides/cloud-in-a-box)
 
 ### Variant 2 - NVMe images
 
-- [Sandbox Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-2.iso) -
-  [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-2.iso.CHECKSUM)
-- [Edge Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-edge-2.iso) -
-  [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-edge-2.iso.CHECKSUM)<BR>
-  Like Sandbox `Variant 2`, with `CLOUD_IN_A_BOX_TYPE=edge` boot parameter.
-- [Kubernetes Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-kubernetes-2.iso) -
-  [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-kubernetes-2.iso.CHECKSUM)<BR>
-  Like Sandbox `Variant 2`, with `CLOUD_IN_A_BOX_TYPE=kubernetes` boot parameter.
-- [Ironic Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-ironic-2.iso) -
-  [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-ironic-2.iso.CHECKSUM)<BR>
-  Like Sandbox `Variant 2`, with `CLOUD_IN_A_BOX_TYPE=ironic` boot parameter.
+ * [Sandbox Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-2.iso) - 
+   [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-2.iso.CHECKSUM)
+ * [Edge Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-edge-2.iso) - 
+   [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-edge-2.iso.CHECKSUM)<BR>
+   Like Sandbox `Variant 2`, with `CLOUD_IN_A_BOX_TYPE=edge` boot parameter.
+ * [Kubernetes Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-kubernetes-2.iso) - 
+   [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-kubernetes-2.iso.CHECKSUM)<BR>
+   Like Sandbox `Variant 2`, with `CLOUD_IN_A_BOX_TYPE=kubernetes` boot parameter.
+ * [Ironic Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-ironic-2.iso) - 
+   [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-ironic-2.iso.CHECKSUM)<BR>
+   Like Sandbox `Variant 2`, with `CLOUD_IN_A_BOX_TYPE=ironic` boot parameter.
 
 ![Disk layout](assets/disklayout-cloud-in-a-box-2.drawio.png "Disk layout")
 
@@ -255,11 +254,9 @@ It has proven to be advantageous to develop these on a system close to the insta
 and then mount the images via the SMB protocol in the DVD emulation of the BMC.
 
 To shorten roundtrip times, you can publish created images via a Samba server on your workstation as follows:
-
 ```
 contrib/samba-local/samba_local.sh
 ```
-
 After initial installation of the image (system is in shutdown), you can just stop this samba instance by hitting `CTRL+c`
 to ensure that the next boot is performed from the local disk.
 
@@ -273,16 +270,14 @@ installation to break. In this case boot some Ubuntu live image and
 erase all data from your disks.
 
 In that case it is a good idea to erase the disk:
-
 ```bash
 dd if=/dev/zero of=/dev/<device> bs=1M count=1024
 ```
-
 (you can use that from the shell prompt available from the installation image or with a live systems)
 
 ## References
 
-- https://curtin.readthedocs.io/en/latest/topics/storage.html
-- https://github.com/cloudymax/pxeless
-- https://jimangel.io/posts/automate-ubuntu-22-04-lts-bare-metal/
-- https://ubuntu.com/server/docs/install/autoinstall-reference
+* https://curtin.readthedocs.io/en/latest/topics/storage.html
+* https://github.com/cloudymax/pxeless
+* https://jimangel.io/posts/automate-ubuntu-22-04-lts-bare-metal/
+* https://ubuntu.com/server/docs/install/autoinstall-reference

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ interface2_asn: '65404'
 interface2_name: enp2s0f1np1
 ipv4_base: 10.10.21.
 ipv6_base: 'fd0c:cc24:75a0:1:10:10:21:'
+ipv6_hex: 'false'
 layer3_underlay: 'true'
 variant: osism-1
 password_hash: $5$H2wkOHUVMIm2Yl2n$2AR/A2ILtgZcWx5UXL6N56Ha/wkdGvs0w5sFUMQ3iaB

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Node Images
 
 | :zap: When booting from one of these images, all data on the disks will be destroyed without confirmation. :zap: |
-|------------------------------------------------------------------------------------------------------------------|
+| ---------------------------------------------------------------------------------------------------------------- |
 
 ## Usage of the node images
 
@@ -13,9 +13,9 @@ The disks used must be at least 480 GByte in size.
 
 1. Connect one ore more ethernet ports and provide DHCP with gateway- and DNS access
 2. Add the installation media to your system
-   * Copy image to USB stick
-   * Place the image on your network provisioning environment
-    (Redfish-BMC Mount)
+   - Copy image to USB stick
+   - Place the image on your network provisioning environment
+     (Redfish-BMC Mount)
 3. Boot from the device
 4. Mount the image in the BMC in another way
 5. Installation is performed, system shuts down afterwards
@@ -23,8 +23,8 @@ The disks used must be at least 480 GByte in size.
 7. After the first boot the system shuts down once more
 8. Start the system, system is ready for use, by default DHCP is tried on all available interfaces
 9. Perform a SSH-login
-   * user: `osism` (alternatively use `dragon` after the 2nd deployment run)
-   * password: `password`
+   - user: `osism` (alternatively use `dragon` after the 2nd deployment run)
+   - password: `password`
 
 ### Installing images with "Routing on the Host"
 
@@ -37,16 +37,16 @@ These parameters are listed in the file `parameters-routing-on-the-host.yml.samp
 The installation is then carried out as follows:
 
 1. Configure the BMC of the server hardware and configure the following properties
-   * The hostname of the system
-   * The BMC IP address
+   - The hostname of the system
+   - The BMC IP address
      (the last number of the IPv4 adress is used for building the node ASN, the node IPs, ..)
-   * Configure the involved switches to have a BGP peering with the host
+   - Configure the involved switches to have a BGP peering with the host
 2. Build a node image specific for your environment
    (see [parameters-routing-on-the-host.yml.sample](./parameters-routing-on-the-host.yml.sample)
 3. Add the installation media to your system
-   * Copy image to USB stick
-   * Place the image on your network provisioning environment
-    (Redfish-BMC Mount)
+   - Copy image to USB stick
+   - Place the image on your network provisioning environment
+     (Redfish-BMC Mount)
 4. Boot from the device
    Installation is performed, system shuts down afterwards
 5. Unmount the device or remove it and start system again
@@ -54,8 +54,8 @@ The installation is then carried out as follows:
 7. Start the system, system is ready for use
    (System starts with a ready to use network setup: dummy interface, frr-config, ...)
 8. Perform a SSH-login
-   * user: `osism` (alternatively use `dragon` after the 2nd deployment run)
-   * password: `password`
+   - user: `osism` (alternatively use `dragon` after the 2nd deployment run)
+   - password: `password`
 
 ## Creation of specific images
 
@@ -109,6 +109,7 @@ $ ./create-image.sh --build node-image-build-osism-1 --parameters layer3-underla
 Created context (yaml):
 ---
 asn_node_base: '42100210'
+asn_part_digits: '0'
 description: Two mirrored NVME disks with a enhanced set of predefined logical volumes
   (/dev/nvme3n1 and /dev/nvme4n1)
 interface1_asn: '65405'
@@ -126,12 +127,13 @@ ssh_public_key_user_osism: '# no key specified'
 ```
 
 Build the image:
-````bash
+
+```bash
 $ ./create-image.sh \
     --build node-image-build-osism-1 \
     --config Supermicro_A2SDV-8C-LN8F.yml \
     --parameters "ipv6_base=fd0c:cc24:75a0:1:10:10:21:" "layer3-underlay=true"
-````
+```
 
 ### Charateristics of layer3_underlay deployments
 
@@ -140,13 +142,13 @@ The parameter `layer3_underlay: 'true'` enables the support for layer3 underlays
 The logic currently implemented is relatively simple and behaves as follows:
 
 - The following must be configured on the system's BMC:
-   - the hostname of the system
-   - The BMC IPv4
+  - the hostname of the system
+  - The BMC IPv4
 - The last group of numbers is taken from the BMC IPv4 configured in the system
   and used as the basis for other configurations (`node-suffix`):
-   - the IPV4 of the “dummy0” interface: `<ipv4_base><node-suffix>>`
-   - the IPV6 of the “dummy0” interface : `<ipv6_base><node-suffix>`
-   - the node ASN of the FRR instance of the node: `<asn_node_base><node-suffix>`
+  - the IPV4 of the “dummy0” interface: `<ipv4_base><node-suffix>>`
+  - the IPV6 of the “dummy0” interface : `<ipv6_base><node-suffix>`
+  - the node ASN of the FRR instance of the node: `<asn_node_base><node-suffix>`
 - The image installs itself with deactivated IPv6 Router Advertisements because otherwise Ubuntu Autoinstall
   tries to reach package sources (so no internet connection is necessary)
 - The names of two Ethernet interfaces and the corresponding ASNs of the switches must be specified (e.g. `interface1_asn` and `interface1_name`)
@@ -157,27 +159,27 @@ The logic currently implemented is relatively simple and behaves as follows:
 
 #### Variant 1
 
-[Standard Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-1.iso) - 
-  [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-1.iso.CHECKSUM)
+[Standard Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-1.iso) -
+[[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-1.iso.CHECKSUM)
 
 ![Disk layout](assets/disklayout-1.drawio.png "Disk layout")
 
 #### Variant 2
 
-* [Standard Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-2.iso) - 
+- [Standard Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-2.iso) -
   [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-2.iso.CHECKSUM)
-* Regio Cloud Images<BR>
+- Regio Cloud Images<BR>
   used for the REGIO.cloud environment, variants of the used devices.
-  * [OSISM 1](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-1.iso) -
+  - [OSISM 1](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-1.iso) -
     [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-1.iso.CHECKSUM)<BR>
     Like `Variant 2`, with `/dev/nvme3n1` and `/dev/nvme4n1`<BR>
-  * [OSISM 2](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-2.iso) - 
+  - [OSISM 2](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-2.iso) -
     [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-2.iso.CHECKSUM)<BR>
     Like `Variant 2`, with `/dev/nvme4n1` and `/dev/nvme5n1`<BR>
-  * [OSISM 3](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-3.iso) - 
+  - [OSISM 3](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-3.iso) -
     [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-3.iso.CHECKSUM)<BR>
     Like `Variant 2`, with `/dev/nvme2n1` and `/dev/nvme3n1`<BR>
-  * [OSISM 4](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-4.iso) - 
+  - [OSISM 4](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-4.iso) -
     [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-osism-4.iso.CHECKSUM)<BR>
     Like `Variant 2`, with `/dev/nvme0n1` and `/dev/nvme1n1`<BR>
 
@@ -185,15 +187,15 @@ The logic currently implemented is relatively simple and behaves as follows:
 
 #### Variant 3
 
-[Standard Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-3.iso) - 
-  [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-3.iso.CHECKSUM)
+[Standard Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-3.iso) -
+[[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-3.iso.CHECKSUM)
 
 ![Disk layout](assets/disklayout-3.drawio.png "Disk layout")
 
 #### Variant 4
 
-[Standard Images](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-4.iso) - 
-  [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-4.iso.CHECKSUM)
+[Standard Images](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-4.iso) -
+[[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-4.iso.CHECKSUM)
 
 ![Disk layout](assets/disklayout-4.drawio.png "Disk layout")
 
@@ -203,12 +205,12 @@ The [cloud in a box](https://osism.tech/docs/guides/other-guides/cloud-in-a-box)
 
 ### Variant 1 - SCSI images
 
-* [Sandbox Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-1.iso) - 
+- [Sandbox Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-1.iso) -
   [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-1.iso.CHECKSUM)
-* [Kubernetes Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-kubernetes-1.iso) - 
+- [Kubernetes Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-kubernetes-1.iso) -
   [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-kubernetes-1.iso.CHECKSUM)<BR>
   Like Sandbox `Variant 1`, with `CLOUD_IN_A_BOX_TYPE=kubernetes` boot parameter.
-* [Ironic Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-ironic-1.iso) - 
+- [Ironic Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-ironic-1.iso) -
   [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-ironic-1.iso.CHECKSUM)<BR>
   Like Sandbox `Variant 1`, with `CLOUD_IN_A_BOX_TYPE=ironic` boot parameter.
 
@@ -216,17 +218,17 @@ The [cloud in a box](https://osism.tech/docs/guides/other-guides/cloud-in-a-box)
 
 ### Variant 2 - NVMe images
 
- * [Sandbox Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-2.iso) - 
-   [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-2.iso.CHECKSUM)
- * [Edge Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-edge-2.iso) - 
-   [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-edge-2.iso.CHECKSUM)<BR>
-   Like Sandbox `Variant 2`, with `CLOUD_IN_A_BOX_TYPE=edge` boot parameter.
- * [Kubernetes Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-kubernetes-2.iso) - 
-   [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-kubernetes-2.iso.CHECKSUM)<BR>
-   Like Sandbox `Variant 2`, with `CLOUD_IN_A_BOX_TYPE=kubernetes` boot parameter.
- * [Ironic Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-ironic-2.iso) - 
-   [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-ironic-2.iso.CHECKSUM)<BR>
-   Like Sandbox `Variant 2`, with `CLOUD_IN_A_BOX_TYPE=ironic` boot parameter.
+- [Sandbox Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-2.iso) -
+  [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-2.iso.CHECKSUM)
+- [Edge Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-edge-2.iso) -
+  [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-edge-2.iso.CHECKSUM)<BR>
+  Like Sandbox `Variant 2`, with `CLOUD_IN_A_BOX_TYPE=edge` boot parameter.
+- [Kubernetes Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-kubernetes-2.iso) -
+  [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-kubernetes-2.iso.CHECKSUM)<BR>
+  Like Sandbox `Variant 2`, with `CLOUD_IN_A_BOX_TYPE=kubernetes` boot parameter.
+- [Ironic Image](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-ironic-2.iso) -
+  [[SHA256]](https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/osism-node-image/ubuntu-autoinstall-cloud-in-a-box-ironic-2.iso.CHECKSUM)<BR>
+  Like Sandbox `Variant 2`, with `CLOUD_IN_A_BOX_TYPE=ironic` boot parameter.
 
 ![Disk layout](assets/disklayout-cloud-in-a-box-2.drawio.png "Disk layout")
 
@@ -253,9 +255,11 @@ It has proven to be advantageous to develop these on a system close to the insta
 and then mount the images via the SMB protocol in the DVD emulation of the BMC.
 
 To shorten roundtrip times, you can publish created images via a Samba server on your workstation as follows:
+
 ```
 contrib/samba-local/samba_local.sh
 ```
+
 After initial installation of the image (system is in shutdown), you can just stop this samba instance by hitting `CTRL+c`
 to ensure that the next boot is performed from the local disk.
 
@@ -269,14 +273,16 @@ installation to break. In this case boot some Ubuntu live image and
 erase all data from your disks.
 
 In that case it is a good idea to erase the disk:
+
 ```bash
 dd if=/dev/zero of=/dev/<device> bs=1M count=1024
 ```
+
 (you can use that from the shell prompt available from the installation image or with a live systems)
 
 ## References
 
-* https://curtin.readthedocs.io/en/latest/topics/storage.html
-* https://github.com/cloudymax/pxeless
-* https://jimangel.io/posts/automate-ubuntu-22-04-lts-bare-metal/
-* https://ubuntu.com/server/docs/install/autoinstall-reference
+- https://curtin.readthedocs.io/en/latest/topics/storage.html
+- https://github.com/cloudymax/pxeless
+- https://jimangel.io/posts/automate-ubuntu-22-04-lts-bare-metal/
+- https://ubuntu.com/server/docs/install/autoinstall-reference

--- a/contrib/create-image.py
+++ b/contrib/create-image.py
@@ -182,6 +182,7 @@ def create_context(
         "asn_node_base": "42100210",
         "ipv4_base": "10.10.21.",
         "ipv6_base": "fd0c:cc24:75a0:1:10:10:21:",
+        "ipv6_hex": "false",
         "interface1_name": "enp2s0f0np0",
         "interface2_name": "enp2s0f1np1",
         "interface1_asn": "65405",

--- a/contrib/create-image.py
+++ b/contrib/create-image.py
@@ -180,6 +180,7 @@ def create_context(
     context_data_default = {
         "layer3_underlay": "false",
         "asn_node_base": "42100210",
+        "asn_part_digits": "0",
         "ipv4_base": "10.10.21.",
         "ipv6_base": "fd0c:cc24:75a0:1:10:10:21:",
         "ipv6_hex": "false",

--- a/parameters-routing-on-the-host.yml.sample
+++ b/parameters-routing-on-the-host.yml.sample
@@ -1,6 +1,8 @@
 ---
 # The last byte of the BMC ip is added
 asn_node_base: '42100210'
+# Fill ASN part with leading zeroes to make it always 2 digits long
+asn_part_digits: 2
 description: Two mirrored NVMe disks with a enhanced set of predefined logical volumes
   (/dev/nvme3n1 and /dev/nvme4n1)
 interface1_asn: '65405'

--- a/parameters-routing-on-the-host.yml.sample
+++ b/parameters-routing-on-the-host.yml.sample
@@ -1,5 +1,5 @@
 ---
-# The last number of the BMC ip is added (2 digits)
+# The last byte of the BMC ip is added
 asn_node_base: '42100210'
 description: Two mirrored NVMe disks with a enhanced set of predefined logical volumes
   (/dev/nvme3n1 and /dev/nvme4n1)
@@ -7,9 +7,11 @@ interface1_asn: '65405'
 interface1_name: enp2s0f0np0
 interface2_asn: '65404'
 interface2_name: enp2s0f1np1
-# The last number of the BMC ip is added (2 digits)
+# The last byte of the BMC ip is added
 ipv4_base: 10.10.21.
-# The last number of the BMC ip is added (2 digits)
+# The last byte of the BMC ip is added
 ipv6_base: 'fd0c:cc24:75a0:1:10:10:21:'
+# Convert last number of BMC to HEX for IPv6 if set to true
+ipv6_hex: false
 layer3_underlay: 'true'
 variant: osism-1

--- a/templates/frr/01-osism.yaml.j2
+++ b/templates/frr/01-osism.yaml.j2
@@ -16,8 +16,8 @@ network:
   ethernets:
     dummy0:
         addresses:
-        - {{ ipv4_base }}OSISM_IP/32
-        - {{ ipv6_base }}OSISM_IP/128
+        - {{ ipv4_base }}OSISM_IP4/32
+        - {{ ipv6_base }}OSISM_IP6/128
     {{ interface1_name }}:
         mtu: 9100
         dhcp4: no

--- a/templates/frr/frr.conf.j2
+++ b/templates/frr/frr.conf.j2
@@ -4,10 +4,10 @@ hostname OSISM_HOST
 log syslog informational
 service integrated-vtysh-config
 !
-router bgp {{ asn_node_base }}OSISM_IP
+router bgp {{ asn_node_base }}OSISM_IP4
  no bgp ebgp-requires-policy
  bgp bestpath as-path multipath-relax
- bgp router-id {{ ipv4_base }}OSISM_IP
+ bgp router-id {{ ipv4_base }}OSISM_IP4
  neighbor {{ interface1_name }} interface remote-as {{ interface1_asn }}
  neighbor {{ interface2_name }} interface remote-as {{ interface2_asn }}
  !
@@ -32,11 +32,11 @@ route-map bgp_out permit 10
 exit
 !
 route-map RM_SET_SRC4 permit 10
- set src {{ ipv4_base }}OSISM_IP
+ set src {{ ipv4_base }}OSISM_IP4
 exit
 !
 route-map RM_SET_SRC6 permit 10
- set src {{ ipv6_base }}OSISM_IP
+ set src {{ ipv6_base }}OSISM_IP6
 exit
 !
 ip protocol bgp route-map RM_SET_SRC4

--- a/templates/frr/frr.conf.j2
+++ b/templates/frr/frr.conf.j2
@@ -4,7 +4,7 @@ hostname OSISM_HOST
 log syslog informational
 service integrated-vtysh-config
 !
-router bgp {{ asn_node_base }}OSISM_IP4
+router bgp {{ asn_node_base }}OSISM_ASN
  no bgp ebgp-requires-policy
  bgp bestpath as-path multipath-relax
  bgp router-id {{ ipv4_base }}OSISM_IP4

--- a/templates/frr/install.sh.j2
+++ b/templates/frr/install.sh.j2
@@ -6,9 +6,9 @@ BASE="/root/frr"
 SYSTEM_HOSTNAME="$(ipmitool dcmi get_mc_id_string|awk '/^.*:/{hostname=$0;gsub(/^(..*): /, "", hostname);printf("%s", hostname); exit}')"
 BMC_IP="$(ipmitool lan print |awk '/^IP Address[ ]*:/{hostname=$0;gsub(/^(..*): /, "", hostname);printf("%s", hostname); exit}')"
 IP4_SUFFIX="$(echo "$BMC_IP"|grep -P -oh '\d+$')"
-IP6_SUFFIX={% if ipv6_hex == 'true' %}"$(printf "%x" "$IP4_SUFFIX")"{% else %}$IP4_SUFFIX{% endif %}
+IP6_SUFFIX={% if ipv6_hex | bool %}"$(printf "%x" "$IP4_SUFFIX")"{% else %}$IP4_SUFFIX{% endif %}
 
-echo "Name is: $SYSTEM_HOSTNAME, IPv4 suffix is: $IP4_SUFFIX, BMC IP is: $BMC_IP"
+echo "Name is: $SYSTEM_HOSTNAME, IPv4 suffix is: $IP4_SUFFIX, IPv6 suffix is: $IP6_SUFFIX, BMC IP is: $BMC_IP"
 
 dpkg -i  $BASE/*.deb
 # otherwise, apt-get autoremove revoves the packages at the end of the installation

--- a/templates/frr/install.sh.j2
+++ b/templates/frr/install.sh.j2
@@ -7,8 +7,9 @@ SYSTEM_HOSTNAME="$(ipmitool dcmi get_mc_id_string|awk '/^.*:/{hostname=$0;gsub(/
 BMC_IP="$(ipmitool lan print |awk '/^IP Address[ ]*:/{hostname=$0;gsub(/^(..*): /, "", hostname);printf("%s", hostname); exit}')"
 IP4_SUFFIX="$(echo "$BMC_IP"|grep -P -oh '\d+$')"
 IP6_SUFFIX={% if ipv6_hex | bool %}"$(printf "%x" "$IP4_SUFFIX")"{% else %}$IP4_SUFFIX{% endif %}
+ASN_SUFFIX="$(printf '%0{{ asn_part_digits }}d\n' $IP4_SUFFIX)"
 
-echo "Name is: $SYSTEM_HOSTNAME, IPv4 suffix is: $IP4_SUFFIX, IPv6 suffix is: $IP6_SUFFIX, BMC IP is: $BMC_IP"
+echo "Name is: $SYSTEM_HOSTNAME, IPv4 suffix is: $IP4_SUFFIX, IPv6 suffix is: $IP6_SUFFIX, ASN suffix is: $ASN_SUFFIX, BMC IP is: $BMC_IP"
 
 dpkg -i  $BASE/*.deb
 # otherwise, apt-get autoremove revoves the packages at the end of the installation
@@ -20,7 +21,7 @@ echo $SYSTEM_HOSTNAME > /etc/hostname
 rm -f /etc/netplan/00-installer-config.yaml
 sed -e "s/OSISM_IP4/$IP4_SUFFIX/" -e "s/OSISM_IP6/$IP6_SUFFIX/" $BASE/01-osism.yaml > /etc/netplan/01-osism.yaml
 chmod 600 /etc/netplan/01-osism.yaml
-sed -e "s/OSISM_IP4/$IP4_SUFFIX/" -e "s/OSISM_IP6/$IP6_SUFFIX/" -e "s/OSISM_HOST/$SYSTEM_HOSTNAME/" $BASE/frr.conf > /etc/frr/frr.conf
+sed -e "s/OSISM_IP4/$IP4_SUFFIX/" -e "s/OSISM_IP6/$IP6_SUFFIX/" -e "s/OSISM_ASN/$ASN_SUFFIX/" -e "s/OSISM_HOST/$SYSTEM_HOSTNAME/" $BASE/frr.conf > /etc/frr/frr.conf
 cp $BASE/daemons /etc/frr/
 cp $BASE/05-dummy0.netdev /etc/systemd/network/
 chmod 600 /etc/systemd/network/05-dummy0.netdev

--- a/templates/frr/install.sh.j2
+++ b/templates/frr/install.sh.j2
@@ -5,9 +5,10 @@ set -x
 BASE="/root/frr"
 SYSTEM_HOSTNAME="$(ipmitool dcmi get_mc_id_string|awk '/^.*:/{hostname=$0;gsub(/^(..*): /, "", hostname);printf("%s", hostname); exit}')"
 BMC_IP="$(ipmitool lan print |awk '/^IP Address[ ]*:/{hostname=$0;gsub(/^(..*): /, "", hostname);printf("%s", hostname); exit}')"
-IP_SUFFIX="$(echo "$BMC_IP"|grep -P -oh '\d+$')"
+IP4_SUFFIX="$(echo "$BMC_IP"|grep -P -oh '\d+$')"
+IP6_SUFFIX={% if ipv6_hex == 'true' %}"$(printf "%x" "$IP4_SUFFIX")"{% else %}$IP4_SUFFIX{% endif %}
 
-echo "Name is: $SYSTEM_HOSTNAME, IP suffix is: $IP_SUFFIX, BMC IP is: $BMC_IP"
+echo "Name is: $SYSTEM_HOSTNAME, IPv4 suffix is: $IP4_SUFFIX, BMC IP is: $BMC_IP"
 
 dpkg -i  $BASE/*.deb
 # otherwise, apt-get autoremove revoves the packages at the end of the installation
@@ -17,9 +18,9 @@ echo $SYSTEM_HOSTNAME > /etc/hostname
 
 
 rm -f /etc/netplan/00-installer-config.yaml
-sed -e "s/OSISM_IP/$IP_SUFFIX/" $BASE/01-osism.yaml > /etc/netplan/01-osism.yaml
+sed -e "s/OSISM_IP4/$IP4_SUFFIX/" -e "s/OSISM_IP6/$IP6_SUFFIX/" $BASE/01-osism.yaml > /etc/netplan/01-osism.yaml
 chmod 600 /etc/netplan/01-osism.yaml
-sed -e "s/OSISM_IP/$IP_SUFFIX/" -e "s/OSISM_HOST/$SYSTEM_HOSTNAME/" $BASE/frr.conf > /etc/frr/frr.conf
+sed -e "s/OSISM_IP4/$IP4_SUFFIX/" -e "s/OSISM_IP6/$IP6_SUFFIX/" -e "s/OSISM_HOST/$SYSTEM_HOSTNAME/" $BASE/frr.conf > /etc/frr/frr.conf
 cp $BASE/daemons /etc/frr/
 cp $BASE/05-dummy0.netdev /etc/systemd/network/
 chmod 600 /etc/systemd/network/05-dummy0.netdev
@@ -44,4 +45,4 @@ fi
 
 systemctl restart frr
 
-echo "\n - \S - IP - {{ ipv4_base }}.${IP_SUFFIX}" > /etc/issue
+echo "\n - \S - IP - {{ ipv4_base }}.${IP4_SUFFIX}" > /etc/issue


### PR DESCRIPTION
IPv6 addresses are usually express as HEX.

e.g. the 254th address expressed in IPv4 is `10.0.0.254` but in IPv6 it would be `2001:db8::fd`. `2001:db8::254` would actually be the `596th` address.

This behaviour can be enabled by setting `ipv6_hex='true'`

Also edited some (supposedly?) misleading hints. I could not find any reference of why 2 digits will be added instead of the entire byte